### PR TITLE
Fix rapid attacks bug

### DIFF
--- a/Assets/Scripts/Battle/BattleSystem.cs
+++ b/Assets/Scripts/Battle/BattleSystem.cs
@@ -62,6 +62,8 @@ public class BattleSystem : MonoBehaviour
 
     IEnumerator PerformPlayerMove()
     {
+        state = BattleState.Busy;
+
         var move = playerMonster.Monster.Moves[currentMove];
         move.Energy--;
         yield return dialogBox.TypeDialog($"{playerMonster.Monster.Base.Name} used {move.Base.Name}!");


### PR DESCRIPTION
# Description

Set battle state to busy to prevent user from attacking many times

Fixes #23 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually. Play a battle, hit Z as many times as you want. Control is not given back to the player until the appropriate time.

**Test Configuration**:
* Build No: 1001
* OS: W10

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
