### PR TITLE
Fix attacking out of turn when switching monsters

### DIFF
--- a/Assets/Scripts/Battle/BattleSystem.cs
+++ b/Assets/Scripts/Battle/BattleSystem.cs
@@ -162,8 +162,10 @@ public class BattleSystem : MonoBehaviour
 
     IEnumerator SwitchMonster(Monster newMonster)
     {
+        bool isSwitchForced = true;
         if (playerMonster.Monster.CurrentHp > 0)
         {
+            isSwitchForced = false;
             yield return dialogBox.TypeDialog($"{playerMonster.Monster.Base.Name}, fall back!");
             playerMonster.PlayDownedAnimation(); //TODO - create animation for returning to party
             yield return new WaitForSeconds(2f);
@@ -172,7 +174,10 @@ public class BattleSystem : MonoBehaviour
         dialogBox.SetMoveList(newMonster.Moves);
         yield return dialogBox.TypeDialog($"You have switched to {newMonster.Base.Name}!");
 
-        StartCoroutine(EnemyMove());
+        if (isSwitchForced)
+            CheckWhoIsFaster();
+        else
+            StartCoroutine(EnemyMove());
     }
 
     void CheckIfBattleIsOver(BattleMonster downedMonster)
@@ -194,7 +199,7 @@ public class BattleSystem : MonoBehaviour
         if (playerMonster.Monster.Speed >= enemyMonster.Monster.Speed)
             ActionSelection();
         else
-            StartCoroutine(EnemyMove());
+            StartCoroutine(EnemyMove());   
     }
 
     void BattleOver(bool won)


### PR DESCRIPTION
# Description

*Add check if switch is forced, if so call CheckWhoIsFaster

Fixes #42 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually

**Test Configuration**:
* Build No: 1.0.2
* OS: W10

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
