### PR TITLE
Fix use moves with no energy bug

### DIFF
--- a/Assets/Scripts/Battle/BattleDialogBox.cs
+++ b/Assets/Scripts/Battle/BattleDialogBox.cs
@@ -72,6 +72,11 @@ public class BattleDialogBox : MonoBehaviour
 
         energyText.text = $"Energy: {move.Energy}/{move.Base.Energy}";
         typeText.text = "Type: " + move.Base.Type.ToString();
+
+        if (move.Energy == 0)
+            energyText.color = Color.red;
+        else
+            energyText.color = Color.black;
     }
 
     public void SetMoveList(List<Move> moves)

--- a/Assets/Scripts/Battle/BattleSystem.cs
+++ b/Assets/Scripts/Battle/BattleSystem.cs
@@ -405,6 +405,9 @@ public class BattleSystem : MonoBehaviour
 
         if (Input.GetKeyDown(KeyCode.Z))
         {
+            var move = playerMonster.Monster.Moves[currentMove];
+            if (move.Energy == 0) return;
+
             dialogBox.EnableMoveSelector(false);
             dialogBox.EnableDialogText(true);
             StartCoroutine(ExecuteTurn(BattleAction.Move));

--- a/Assets/Scripts/Monster/Monster.cs
+++ b/Assets/Scripts/Monster/Monster.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 [System.Serializable]
@@ -218,8 +219,10 @@ public class Monster
     //
     public Move GetRandomMove()
     {
-        int i = UnityEngine.Random.Range(0, Moves.Count);
-        return Moves[i];
+        var usableMoves = Moves.Where(m => m.Energy > 0).ToList(); //TODO - handle case with no usable moves
+
+        int i = UnityEngine.Random.Range(0, usableMoves.Count);
+        return usableMoves[i];
     }
 
     public bool OnTurnBegin()


### PR DESCRIPTION
# Description

*Add check to ensure move has energy before use

Fixes #58

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually

**Test Configuration**:
* Build No: 1.0.3
* OS: W10

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
