### PR TITLE
Fix ambiguity in monster dialog

### DIFF
--- a/Assets/Game/Resources/Monsters/Firefly.asset
+++ b/Assets/Game/Resources/Monsters/Firefly.asset
@@ -29,7 +29,7 @@ MonoBehaviour:
   learnableMoves:
   - moveBase: {fileID: 11400000, guid: a20f484b53130084c890b7cc758964de, type: 2}
     levelLearned: 1
-  - moveBase: {fileID: 11400000, guid: 8d7e7bbdab74fda4d8ec4d9c05e6f9d7, type: 2}
+  - moveBase: {fileID: 11400000, guid: 63e6de78267fa414ebcd207c38b25351, type: 2}
     levelLearned: 4
   - moveBase: {fileID: 11400000, guid: d48926211c4fedc4a9d577586feba815, type: 2}
     levelLearned: 7

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -418,10 +418,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   monsters:
-  - _base: {fileID: 11400000, guid: 875c84c591e13614ca6291675fe33305, type: 2}
-    level: 4
   - _base: {fileID: 11400000, guid: 08fe71a8bca62d0468ada7da52ccd5a7, type: 2}
     level: 8
+  - _base: {fileID: 11400000, guid: 875c84c591e13614ca6291675fe33305, type: 2}
+    level: 4
   - _base: {fileID: 11400000, guid: 037162b05ccdadf43a507fd23d5b7d64, type: 2}
     level: 7
   - _base: {fileID: 11400000, guid: 875c84c591e13614ca6291675fe33305, type: 2}

--- a/Assets/Scripts/Battle/BattleSystem.cs
+++ b/Assets/Scripts/Battle/BattleSystem.cs
@@ -121,7 +121,12 @@ public class BattleSystem : MonoBehaviour
         }
 
         yield return ShowStatusChanges(attackingMonster.Monster);
-        yield return dialogBox.TypeDialog($"{attackingMonster.Monster.Base.Name} used {move.Base.Name}!");
+
+        if (attackingMonster.IsPlayerMonster)
+            yield return dialogBox.TypeDialog($"{attackingMonster.Monster.Base.Name} used {move.Base.Name}!");
+        else
+            yield return dialogBox.TypeDialog($"Enemy {attackingMonster.Monster.Base.Name} used {move.Base.Name}!");
+
         move.Energy--;
 
         if (CheckIfMoveHits(move, attackingMonster.Monster, defendingMonster.Monster))
@@ -159,7 +164,12 @@ public class BattleSystem : MonoBehaviour
             if (defendingMonster.Monster.CurrentHp <= 0)
             {
                 defendingMonster.PlayDownedAnimation();
-                yield return dialogBox.TypeDialog($"{defendingMonster.Monster.Base.Name} has been taken down!");
+
+                if (defendingMonster.IsPlayerMonster)
+                    yield return dialogBox.TypeDialog($"{defendingMonster.Monster.Base.Name} has been taken down!");
+                else
+                    yield return dialogBox.TypeDialog($"Enemy {defendingMonster.Monster.Base.Name} has been taken down!");
+
                 yield return new WaitForSeconds(2f);
 
                 CheckIfBattleIsOver(defendingMonster);
@@ -167,7 +177,10 @@ public class BattleSystem : MonoBehaviour
         }
         else
         {
-            yield return dialogBox.TypeDialog($"{attackingMonster.Monster.Base.Name} missed their attack!");
+            if (attackingMonster.IsPlayerMonster)
+                yield return dialogBox.TypeDialog($"{attackingMonster.Monster.Base.Name} missed their attack!");
+            else
+                yield return dialogBox.TypeDialog($"Enemy {attackingMonster.Monster.Base.Name} missed their attack!");
         }        
     }
 
@@ -249,7 +262,12 @@ public class BattleSystem : MonoBehaviour
         if (attackingMonster.Monster.CurrentHp <= 0)
         {
             attackingMonster.PlayDownedAnimation();
-            yield return dialogBox.TypeDialog($"{attackingMonster.Monster.Base.Name} has been taken down!");
+
+            if (attackingMonster.IsPlayerMonster)
+                yield return dialogBox.TypeDialog($"{attackingMonster.Monster.Base.Name} has been taken down!");
+            else
+                yield return dialogBox.TypeDialog($"Enemy {attackingMonster.Monster.Base.Name} has been taken down!");
+
             yield return new WaitForSeconds(2f);
 
             CheckIfBattleIsOver(attackingMonster);


### PR DESCRIPTION
# Description

*Add Enemy prefix to dialog for enemy monster text

There is still ambiguity in the status effect messages. The `ConditionDB` class passes the status message to the queue but it uses an instance of `Monster` instead of `BattleMonster`. The `IsPlayerMonster` variable is currently only used in the `BattleMonster` class so it isn't available in the `ConditionDB` messages. For now this will be left ambiguous and may or may not be addressed later. 

Fixes #59

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually

**Test Configuration**:
* Build No: 1.0.3
* OS: W10

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
