### PR TITLE
Fix NPC walk thru objects

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -362,7 +362,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 199644580}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -4.5, y: 2.8, z: 0}
+  m_LocalPosition: {x: -4.5, y: 3.8, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -496,7 +496,9 @@ GameObject:
   - component: {fileID: 225907027}
   - component: {fileID: 225907025}
   - component: {fileID: 225907026}
-  m_Layer: 0
+  - component: {fileID: 225907029}
+  - component: {fileID: 225907028}
+  m_Layer: 9
   m_Name: Player
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -651,6 +653,53 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   moveSpeed: 5
+--- !u!50 &225907028
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 225907021}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!61 &225907029
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 225907021}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.00000011920929, y: -0.040094137}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 2}
+    newSize: {x: 0.84375, y: 1.40625}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.95990586, y: 1.278306}
+  m_EdgeRadius: 0
 --- !u!1 &251412312
 GameObject:
   m_ObjectHideFlags: 0
@@ -2920,10 +2969,10 @@ MonoBehaviour:
     - Hey, welcome to the world of monsters.
     - Good luck!
   movementPattern:
-  - {x: 2, y: 0}
-  - {x: 0, y: 2}
-  - {x: -2, y: 0}
-  - {x: 0, y: -2}
+  - {x: 4, y: 0}
+  - {x: 0, y: 4}
+  - {x: -4, y: 0}
+  - {x: 0, y: -4}
   movementPatternTime: 3
 --- !u!61 &870110088
 BoxCollider2D:
@@ -3031,7 +3080,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 870110084}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -2.5, y: 2.8, z: 0}
+  m_LocalPosition: {x: -6.5, y: -1.8, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -4435,6 +4484,9 @@ MonoBehaviour:
   interactLayer:
     serializedVersion: 2
     m_Bits: 256
+  playerLayer:
+    serializedVersion: 2
+    m_Bits: 512
 --- !u!1 &1404901494
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Character/Character.cs
+++ b/Assets/Scripts/Character/Character.cs
@@ -32,7 +32,7 @@ public class Character : MonoBehaviour
         targetPos.x += moveVector.x;
         targetPos.y += moveVector.y;
 
-        if (!IsWalkable(targetPos))
+        if (!IsPathWalkable(targetPos))
             yield break;
 
         IsMoving = true;
@@ -62,6 +62,20 @@ public class Character : MonoBehaviour
         {
             return false;
         }
+        return true;
+    }
+
+    private bool IsPathWalkable(Vector3 targetPath)
+    {
+        var path = targetPath - transform.position;
+        var direction = path.normalized;
+        var origin = transform.position + direction; // start at the next tile over or we collide with the character
+        var length = path.magnitude - 1; // 1 less because we start checking from the next tile over
+
+        if (Physics2D.BoxCast(origin, new Vector2(0.2f, 0.2f), 0f, direction, length,
+            MapLayers.Instance.ObjectsLayer | MapLayers.Instance.InteractLayer | MapLayers.Instance.PlayerLayer) == true)
+            return false; // we found a collider on the path
+
         return true;
     }
 }

--- a/Assets/Scripts/Character/NPCController.cs
+++ b/Assets/Scripts/Character/NPCController.cs
@@ -39,8 +39,12 @@ public class NPCController : MonoBehaviour, Interactable
     {
         state = NPCState.Walking;
 
+        var oldPos = transform.position;
+
         yield return character.Move(movementPattern[currentMovement]);
-        currentMovement = (currentMovement + 1) % movementPattern.Count;
+
+        if (transform.position != oldPos)
+            currentMovement = (currentMovement + 1) % movementPattern.Count;
 
         state = NPCState.Idle;
     }

--- a/Assets/Scripts/Gameplay/MapLayers.cs
+++ b/Assets/Scripts/Gameplay/MapLayers.cs
@@ -7,6 +7,7 @@ public class MapLayers : MonoBehaviour
     [SerializeField] LayerMask objectsLayer;
     [SerializeField] LayerMask encountersLayer;
     [SerializeField] LayerMask interactLayer;
+    [SerializeField] LayerMask playerLayer;
 
     public static MapLayers Instance { get; set; }
 
@@ -23,5 +24,9 @@ public class MapLayers : MonoBehaviour
     }
     public LayerMask InteractLayer {
         get => interactLayer;
+    }
+
+    public LayerMask PlayerLayer {
+        get => playerLayer;
     }
 }

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -11,10 +11,10 @@ TagManager:
   - 
   - Water
   - UI
-  - ObjectsLayer
-  - EncountersLayer
-  - InteractLayer
-  - 
+  - Objects
+  - Encounters
+  - Interact
+  - Player
   - 
   - 
   - 


### PR DESCRIPTION
# Description

*Add check if walking path is clear of objects or player
*Add playerLayer for NPC collision checks

**This is only partially fixed.**
The NPC will check if the path is walkable before moving, and will wait until the path is clear to continue it's pattern. It also will not skip to the next move of the pattern until it completes the current move. This gives full control over the NPC's allowable movement, however, this creates 2 separate issues:

- If the path is obstructed by an object that will not move, the NPC will stay frozen indefinitely. Walking patterns need to be thoroughly tested.
- Once the NPC starts moving, the player is able to cross it's path and it will still move thru the player sprite. Short of checking each step during the path, I don't see a simple fix for this. I think it's OK for now to leave this as is because it's an edge case that may not show up to players very often, and likely won't affect gameplay negatively if it does. 

Keep NPC walking patterns short and it may not show up at all in game. For quest patterns where a scripted NPC comes from off screen, the player movement should be restricted anyways so they cannot intercept the moving NPC.

Fixes #79

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually

**Test Configuration**:
* Build No: 1.0.3
* OS: W10

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
